### PR TITLE
Improve development workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ Then require it: this will register the component globally.
 require('aframe-blink-controls');
 ```
 
+### Development
+
+Use `npm run dev` to run a development build with a number of provided examples on https://localhost:8080 (or alternatively your computer's IP on your network, e.g. for testing on standalone devices).
+
 ### Events
 
 | Event      | Properties of `event.detail`             | Description                      |

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "unpkg": "dist/aframe-blink-controls.min.js",
   "scripts": {
     "dev": "webpack-dev-server --disable-host-check --mode development",
-    "watch": "webpack --mode development --output-filename aframe-blink-controls.js --watch",
-    "dist": "webpack --mode development --output-filename aframe-blink-controls.js && webpack -p --output-filename aframe-blink-controls.min.js && cp dist/aframe-blink-controls.js docs/dist/",
+    "dist": "webpack -p",
     "lint": "eslint src/",
     "prepublish": "npm run dist",
     "start": "npm run dev"
@@ -22,7 +21,8 @@
     "aframe-vr",
     "vr",
     "webxr",
-    "blink-controls"
+    "blink-controls",
+    "teleport"
   ],
   "author": "Jure Triglav, Fernando Serrano (original author of aframe-teleport-controls)",
   "license": "MIT",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,12 +1,29 @@
-const path = require('path');
+const path = require('path')
+const TerserPlugin = require('terser-webpack-plugin')
 
 module.exports = {
+  entry: {
+    'dist/aframe-blink-controls': './src/index.js',
+    'dist/aframe-blink-controls.min': './src/index.js',
+    'docs/dist/aframe-blink-controls': './src/index.js'
+  },
+  output: {
+    filename: '[name].js',
+    path: path.resolve(__dirname)
+  },
+  optimization: {
+    minimize: true,
+    minimizer: [
+      new TerserPlugin({
+        test: /\.min\.js$/i
+      })
+    ]
+  },
   devtool: 'source-map',
   devServer: {
     host: '0.0.0.0',
     disableHostCheck: true,
     https: true,
-    contentBase: path.join(__dirname, 'docs'),
-    publicPath: '/assets/',
-  },
-};
+    contentBase: path.join(__dirname, 'docs')
+  }
+}


### PR DESCRIPTION
This removes the copying of built files and double building and relies on webpack to provide an unminified component to the `docs/` GitHub Pages site, and a minified version for dist.