### PR TITLE
Rename PlaneBufferGeometry to PlaneGeometry

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -606,7 +606,7 @@ AFRAME.registerComponent('blink-controls', {
     return hitEntity
   },
   createDefaultPlane: function (size) {
-    const geometry = new THREE.PlaneBufferGeometry(100, 100)
+    const geometry = new THREE.PlaneGeometry(100, 100)
     geometry.rotateX(-Math.PI / 2)
     const material = new THREE.MeshBasicMaterial({ color: 0xffff00 })
     return new THREE.Mesh(geometry, material)


### PR DESCRIPTION
Rename `PlaneBufferGeometry` to `PlaneGeometry` to remove warning in threejs r144 used in current aframe master.

`PlaneBufferGeometry` was renamed to `PlaneGeometry` a while ago but in threejs r144 they added a warning
"THREE.PlaneBufferGeometry has been renamed to THREE.PlaneGeometry.", see https://github.com/mrdoob/three.js/commit/5acd8ce2cfb7fc29b4fde9775e46041ace9bc055

If did a similar fix recently in aframe https://github.com/aframevr/aframe/pull/5114