### PR TITLE
Fix RAD2DEG undefined with threejs r144

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -510,7 +510,7 @@ AFRAME.registerComponent('blink-controls', {
     this.collisionWorldNormal.copy(collisionNormal)
       .applyMatrix3(this.collisionObjectNormalMatrix).normalize()
     const angleNormals = this.referenceNormal.angleTo(this.collisionWorldNormal)
-    return (THREE.Math.RAD2DEG * angleNormals <= this.data.landingMaxAngle)
+    return (THREE.MathUtils.RAD2DEG * angleNormals <= this.data.landingMaxAngle)
   },
 
   // Utils


### PR DESCRIPTION
With aframe master threejs r144, the page crashes when trying to teleport because `THREE.Math` doesn't exist anymore, we now need to import from `THREE.MathUtils`
This change is still compatible with aframe 1.2.0.

I didn't see this error when I did #20 because I still had the 
```<script>THREE.Math = THREE.MathUtils;</script>``` hack in my page.