### PR TITLE
Added position-warp option

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Support for HTC Vive/Valve Index/HP Reverb G2 etc. controllers is only theoretic
 | incrementalDrawMs | How long the ray animation should be | 500 |
 | snapTurn | If left/right thumbstick axis performs a 45 deg rotation | true |
 | rotateOnTeleport | Will rotate player on teleport, facing the direction where the arrow is pointing | true |
+| teleportationMethod | Set value to `position-warp` to enable this teleportation option. |  |
+| positionWarpDuration | How long the position warp animation should be. | 1000 |
 
 ### Usage
 

--- a/src/index.js
+++ b/src/index.js
@@ -71,7 +71,9 @@ AFRAME.registerComponent('blink-controls', {
     missOpacity: { default: 0.8 },
     hitOpacity: { default: 0.8 },
     snapTurn: { default: true },
-    rotateOnTeleport: { default: true }
+    rotateOnTeleport: { default: true },
+    teleportationMethod: { default: ""},
+    positionWarpDuration: { default: 1000 }
   },
 
   init: function () {
@@ -423,7 +425,17 @@ AFRAME.registerComponent('blink-controls', {
       if (rig.object3D.parent) {
         rig.object3D.parent.worldToLocal(newRigLocalPosition)
       }
-      rig.setAttribute('position', newRigLocalPosition)
+      
+      if (this.data.teleportationMethod === "position-warp") {
+        rig.setAttribute('animation', {
+          property: 'position',
+          to: `${newRigLocalPosition.x} 0 ${newRigLocalPosition.z}`,
+          easing: 'linear',
+          dur: this.data.positionWarpDuration
+        });
+      } else {
+        rig.setAttribute('position', newRigLocalPosition)
+      }
 
       // Also take the headset/camera rotation itself into account
       if (this.data.rotateOnTeleport) {
@@ -432,7 +444,13 @@ AFRAME.registerComponent('blink-controls', {
         this.teleportOriginQuaternion.invert()
         this.teleportOriginQuaternion.multiply(this.hitEntityQuaternion)
         // Rotate the rig based on calculated teleport origin rotation
-        this.cameraRig.object3D.setRotationFromQuaternion(this.teleportOriginQuaternion)
+        if (this.data.teleportationMethod === "position-warp") {
+          setTimeout(() => {
+            this.cameraRig.object3D.setRotationFromQuaternion(this.teleportOriginQuaternion)
+          }, this.data.positionWarpDuration)
+        } else {
+          this.cameraRig.object3D.setRotationFromQuaternion(this.teleportOriginQuaternion)
+        }
       }
 
       // If a rig was not explicitly declared, look for hands and move them proportionally as well


### PR DESCRIPTION
Hi Jure,

As anticipated over X (Twitter), this PR implements a simple edit to your component to add the position warp option.

Reference on the Oculus Techniques and Best Practices:
https://developer.oculus.com/resources/locomotion-design-turns-teleportation/#position-warp

I added the `positionWarpDuration` property to the component's schema so the users can tweak it as they want or need. I initially set its default value to 0.5 sec, but after using this locomotion method in immersive mode for a few minutes, I changed it to 1 sec as it provides more comfort. 

**NOTE**: rather than a fixed speed, the fixed animation duration is an intended design choice: the resulting variable movement speed (proportional to the distance of the selected destinations) is indeed what makes this locomotion method feel natural, producing the result of "walking" to closer destinations and "running" to the ones farther away from the initial position of the user. This is, at least, what I wanted and needed to achieve in my prototype for an in-house project 🙂