### PR TITLE
Respect defaultPlaneSize property when creating default plane

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -628,7 +628,7 @@ AFRAME.registerComponent('blink-controls', {
     return hitEntity
   },
   createDefaultPlane: function (size) {
-    const geometry = new THREE.PlaneGeometry(100, 100)
+    const geometry = new THREE.PlaneGeometry(size, size)
     geometry.rotateX(-Math.PI / 2)
     const material = new THREE.MeshBasicMaterial({ color: 0xffff00 })
     return new THREE.Mesh(geometry, material)
@@ -715,3 +715,4 @@ AFRAME.utils.RayCurve.prototype = {
     }
   })()
 }
+


### PR DESCRIPTION
`this.defaultPlane = this.createDefaultPlane(this.data.defaultPlaneSize)` is called (defaultPlaneSize is 100 by default) but we hard code again the value 100, we need to use the size param here.